### PR TITLE
Update autobuild.sh to include avx build

### DIFF
--- a/autobuild.sh
+++ b/autobuild.sh
@@ -10,9 +10,9 @@ cd ./ODM
 
 env -i git pull origin master
 
-/usr/bin/docker build --no-cache --squash -t opendronemap/odm:latest -f portable.Dockerfile .
+/usr/bin/docker DOCKER_BUILDKIT=1 build --no-cache --squash -t opendronemap/odm:latest -f portable.Dockerfile .
 
-/usr/bin/docker build --no-cache --squash -t opendronemap/odm:latest-avx -f Dockerfile .
+/usr/bin/docker DOCKER_BUILDKIT=1 build --no-cache --squash -t opendronemap/odm:latest-avx -f Dockerfile .
 
 echo $DOCKER_PASS | /usr/bin/docker login -u $DOCKER_USER --password-stdin
 

--- a/autobuild.sh
+++ b/autobuild.sh
@@ -12,14 +12,21 @@ env -i git pull origin master
 
 /usr/bin/docker build --no-cache --squash -t opendronemap/odm:latest -f portable.Dockerfile .
 
+/usr/bin/docker build --no-cache --squash -t opendronemap/odm:latest-avx -f Dockerfile .
+
 echo $DOCKER_PASS | /usr/bin/docker login -u $DOCKER_USER --password-stdin
 
 /usr/bin/docker push opendronemap/odm:latest
+/usr/bin/docker push opendronemap/odm:latest-avx
 
 # Tag
 VERSION=$(cat VERSION)
+VERSION_AVX=$VERSION"-avx"
 /usr/bin/docker tag opendronemap/odm:latest "opendronemap/odm:$VERSION"
 /usr/bin/docker push "opendronemap/odm:$VERSION"
+
+/usr/bin/docker tag opendronemap/odm:latest "opendronemap/odm:$VERSION_AVX"
+/usr/bin/docker push "opendronemap/odm:$VERSION_AVX"
 
 
 if [ -e ./post.sh ]; then


### PR DESCRIPTION
Build with AVX instructions , tag the AVX specific version and push to Docker Hub . Ensuring preserving the current older architecture as the default tag option for end users.